### PR TITLE
add support for custom vhost.d configuration like conf.d

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -54,11 +54,16 @@ NGINX_FILES_PATH=./nginx-data
 # In case you want to add some special configuration to your NGINX Web Proxy you could
 # add your files to ./conf.d/ folder as of sample file 'uploadsize.conf'
 #
+# In addition you can have per vhost configuration files under ./vhost.d/ folder. The sample
+# 'default' shows how to set a header for all vhosts that do that do not  have their own
+# specific configuration.
+#
 # [WARNING] This setting was built to use our `start.sh`.
 #
 # [WARNING] Once you set this options to true all your files will be copied to data
-#           folder (./data/conf.d). If you decide to remove this special configuration
-#           you must delete your files from data folder ./data/conf.d.
+#           folder (./data/conf.d) and vhost folder (./data/vhost.d). If you decide to
+#           remove this special configuration you must delete your files from data folder
+#           (./data/conf.d and ./data/vhost.d).
 #
 #USE_NGINX_CONF_FILES=true
 

--- a/start.sh
+++ b/start.sh
@@ -33,15 +33,15 @@ docker-compose pull
 # Check if user set to use Special Conf Files
 if [ ! -z ${USE_NGINX_CONF_FILES+X} ] && [ "$USE_NGINX_CONF_FILES" = true ]; then
 
-    # Create the conf folder if it does not exists
-    mkdir -p $NGINX_FILES_PATH/conf.d
+    # Create the conf folders if they do not exist
+    mkdir -p $NGINX_FILES_PATH/conf.d $NGINX_FILES_PATH/vhost.d
 
     # Copy the special configurations to the nginx conf folder
-    cp -R ./conf.d/* $NGINX_FILES_PATH/conf.d
+    cp -R ./conf.d ./vhost.d $NGINX_FILES_PATH/
 
     # Check if there was an error and try with sudo
     if [ $? -ne 0 ]; then
-        sudo cp -R ./conf.d/* $NGINX_FILES_PATH/conf.d
+        sudo cp -R ./conf.d ./vhost.d $NGINX_FILES_PATH
     fi
 
     # If there was any errors inform the user

--- a/vhost.d/default
+++ b/vhost.d/default
@@ -1,0 +1,9 @@
+
+#
+# [WARNING] To enable this file you need to uncomment USE_NGINX_CONF_FILES=true in .env file
+#
+# [WARNING] Also, read all the comments in .env about NGINX use special conf files
+#
+
+#  Prevent search engines from indexing 
+add_header X-Robots-Tag noindex;


### PR DESCRIPTION
I needed to provide a custom header which unfortunately cannot be set in the http block (where conf.d sits) because it gets overridden by the vhost directives (see https://www.peterbe.com/plog/be-very-careful-with-your-add_header-in-nginx), so I had to provide it under vhost.d default, but there was no mechanism for that. 

This commit merely add a `vhost.d` directory with a sample `default` configuration file which, like conf.d, get's copied with the correct `.env` configuration. 