### PR TITLE
WIP: bind mount for acme.sh is missing

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,6 +51,7 @@ services:
       - ${NGINX_FILES_PATH:-./data}/vhost.d:/etc/nginx/vhost.d
       - ${NGINX_FILES_PATH:-./data}/html:/usr/share/nginx/html
       - ${NGINX_FILES_PATH:-./data}/certs:/etc/nginx/certs:rw
+      - ${NGINX_FILES_PATH:-./data}/acme.sh:/etc/acme.sh:rw
       - /var/run/docker.sock:/var/run/docker.sock:ro
     environment:
       NGINX_DOCKER_GEN_CONTAINER: ${DOCKER_GEN:-nginx-gen}


### PR DESCRIPTION
**_This is a suggestion, and WILL BREAK EXISTING INSTALLATIONS since it mounts a new directory into the `/etc/acme.sh` please do not blindly apply this_**

Having no fixed mount for acme.sh can cause a loss of your private key and all your signing keys for your domains, which hapend to me yesterday.

I noticed this when I got greeted with lots of:

`too many certificates already issued for exact set of domains`

A restart of the containers confirmed this suspicion:

```
nginx-letsencrypt    | [Wed Dec  9 16:48:07 UTC 2020] Create account key ok.
nginx-letsencrypt    | [Wed Dec  9 16:48:07 UTC 2020] Registering account: https://acme-v02.api.letsencrypt.org/directory
nginx-letsencrypt    | [Wed Dec  9 16:48:08 UTC 2020] Registered
```

Now having this bind-mount for the `/etc/acme.d` will put them where they should be.

Reference: [Readme: nginx-proxy/docker-letsencrypt-nginx-proxy-companion](https://github.com/nginx-proxy/docker-letsencrypt-nginx-proxy-companion#step-2---letsencrypt-nginx-proxy-companion)