### PR TITLE
Docker rootless support

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -121,3 +121,15 @@ DEFAULT_EMAIL=mail@yourdomain.tld
 # https://github.com/nginx-proxy/nginx-proxy#default-host
 #
 DEFAULT_HOST=
+
+#-----------------------------------------------------------------------
+#
+# Docker Rootless
+#
+# In case you want to use this proxy on Docker Rootless (DR) and you also have followed
+# the DR installation from the official documentation (https://docs.docker.com/engine/security/rootless/)
+# Set the following value of the DOCKER_HOST variable that you got in the final info messages after executing
+# the "$ dockerd-rootless-setuptool.sh install" command.
+# For example DOCKER_HOST_PATH=$XDG_RUNTIME_DIR/docker.sock
+# If you are not using Docker Rootless, leave this variable blank
+DOCKER_HOST_ROOTLESS_PATH=

--- a/bin/.env
+++ b/bin/.env
@@ -56,5 +56,5 @@ REPLACE_LETSENCRYPT_SERVICE_NAME="nginx-proxy-automation-letsencrypt"
 #
 #  md5 checksum for .env and docker-compose.yml files
 #
-MD5_SUM_DOCKER_COMPOSE=acb712ecf4c2edd04583032b1cd4da07
-MD5_SUM_ENV_SAMPLE=b299b584d68c1a6f7ac1b1a753a7517d
+MD5_SUM_DOCKER_COMPOSE=7c9ed211bde6eb11d6c71d4f9705f1ad
+MD5_SUM_ENV_SAMPLE=5b0f91894cf1417f5f445369c90bc10a

--- a/bin/.env
+++ b/bin/.env
@@ -56,5 +56,5 @@ REPLACE_LETSENCRYPT_SERVICE_NAME="nginx-proxy-automation-letsencrypt"
 #
 #  md5 checksum for .env and docker-compose.yml files
 #
-MD5_SUM_DOCKER_COMPOSE=7c9ed211bde6eb11d6c71d4f9705f1ad
+MD5_SUM_DOCKER_COMPOSE=f06283de0336cd0f9f7749483586ab45
 MD5_SUM_ENV_SAMPLE=5b0f91894cf1417f5f445369c90bc10a

--- a/bin/fresh-start.sh
+++ b/bin/fresh-start.sh
@@ -429,6 +429,16 @@ while [[ $# -gt 0 ]]; do
     shift 1
     ;;
 
+  # Docker rootless support
+  -dr)
+    USE_DOCKER_ROOTLESS=true
+    shift 1
+    ;;
+  --docker-rootless)
+    USE_DOCKER_ROOTLESS=true
+    shift 1
+    ;;
+
   # IPv4 options
   --ipv4-subnet=*)
     ARG_IPv4_SUBNET="${1#*=}"
@@ -1120,6 +1130,16 @@ DOCKER_HTTPS=${ARG_DOCKER_HTTPS:-"443"}
 # https://github.com/nginx-proxy/nginx-proxy#how-ssl-support-works
 #-----------------------------------------------------------------------
 SSL_POLICY=${ARG_SSL_POLICY:-"Mozilla-Intermediate"}
+
+#-----------------------------------------------------------------------
+# Docker rootless support. Add the current user's docker.sock path (default: blank)
+# Please read the official documentation of installing Docker Rootless:
+# https://docs.docker.com/engine/security/rootless/
+#-----------------------------------------------------------------------
+if [[ "$USE_DOCKER_ROOTLESS" == true ]]; then
+  # Get the current user's $XDG_RUNTIME_DIR and concat with the '/docker.sock'
+  DOCKER_HOST_ROOTLESS_PATH=`echo ${XDG_RUNTIME_DIR}/docker.sock`
+fi
 
 #-----------------------------------------------------------------------
 # Start actions!

--- a/bin/localscript/update-env-new-site-variables.sh
+++ b/bin/localscript/update-env-new-site-variables.sh
@@ -78,5 +78,8 @@ local_update_env_new_site_variables()
     # Default host
     [[ ! $ARG_DEFAULT_HOST == "" ]] && run_function env_update_variable $LOCAL_FILE_PATH "DEFAULT_HOST" "${ARG_DEFAULT_HOST}"
 
+    # Docker rootless support
+    run_function env_update_variable $LOCAL_FILE_PATH "DOCKER_HOST_ROOTLESS_PATH" "$DOCKER_HOST_ROOTLESS_PATH"
+
     return 0
 }

--- a/bin/localscript/usage-fresh-start.sh
+++ b/bin/localscript/usage-fresh-start.sh
@@ -64,6 +64,7 @@ Usage:
                 [--use-nginx-conf-files] [--update-nginx-template]
                 [--yes]
                 [--debug]
+                [--docker-rootless]
 
     Required
     -e | --default-email          Default email address require to issue ssl
@@ -131,6 +132,10 @@ Usage:
     --yes                               Set "yes" to all, use it with caution
     --debug                             Show script debug options
     --silent                            Hide all script message
+    -dr | --docker-rootless             Add Docker rootless support by adding the
+                                        the current user's $XDG_RUNTIME_DIR and
+                                        concat with the '/docker.sock' in the
+                                        DOCKER_HOST_ROOTLESS_PATH .env file.
     -h | --help                         Display this help
 
 ${reset}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       - ${NGINX_FILES_PATH:-./data}/html:/usr/share/nginx/html
       - ${NGINX_FILES_PATH:-./data}/certs:/etc/nginx/certs:rw
       - ${NGINX_FILES_PATH:-./data}/acme.sh:/etc/acme.sh
-      - ${DOCKER_HOST_ROOTLESS_PATH:-/var/run/docker.sock}:ro
+      - ${DOCKER_HOST_ROOTLESS_PATH:-/var/run/docker.sock}:/var/run/docker.sock:ro
     environment:
       NGINX_DOCKER_GEN_CONTAINER: ${DOCKER_GEN_SEVICE_NAME:-nginx-proxy-automation-gen}
       NGINX_PROXY_CONTAINER: ${NGINX_WEB_SEVICE_NAME:-nginx-proxy-automation-web}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       - ${NGINX_FILES_PATH:-./data}/html:/usr/share/nginx/html
       - ${NGINX_FILES_PATH:-./data}/certs:/etc/nginx/certs:ro
       - ${NGINX_FILES_PATH:-./data}/htpasswd:/etc/nginx/htpasswd:ro
-      - /var/run/docker.sock:/tmp/docker.sock:ro
+      - ${DOCKER_HOST_ROOTLESS_PATH:-/var/run/docker.sock}:/tmp/docker.sock:ro
       - ./nginx.tmpl:/etc/docker-gen/templates/nginx.tmpl:ro
     logging:
       driver: ${NGINX_GEN_LOG_DRIVER:-json-file}
@@ -57,7 +57,7 @@ services:
       - ${NGINX_FILES_PATH:-./data}/html:/usr/share/nginx/html
       - ${NGINX_FILES_PATH:-./data}/certs:/etc/nginx/certs:rw
       - ${NGINX_FILES_PATH:-./data}/acme.sh:/etc/acme.sh
-      - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ${DOCKER_HOST_ROOTLESS_PATH:-/var/run/docker.sock}:ro
     environment:
       NGINX_DOCKER_GEN_CONTAINER: ${DOCKER_GEN_SEVICE_NAME:-nginx-proxy-automation-gen}
       NGINX_PROXY_CONTAINER: ${NGINX_WEB_SEVICE_NAME:-nginx-proxy-automation-web}


### PR DESCRIPTION
I added support for Docker Rootless.

This has been possible by adding the possibility to bind the docker.sock to the user's current $XDG_RUNTIME_DIR, which is found in the user's .bashrc file, that he added after installing docker rootless, by following the instructions from the official documentation (https://docs.docker.com/engine/security/rootless/) to run the Docker Daemon as a non-root user.

I have tested this already on an Ubuntu 20.04.2 VPS where I set up Docker rootless according to [the Docker rootless official documentation](https://docs.docker.com/engine/security/rootless/).