### PR TITLE
Osxfix

### DIFF
--- a/bin/fresh-start.sh
+++ b/bin/fresh-start.sh
@@ -18,7 +18,6 @@ if [ $(sed -E "s/^([0-9]*).*$/\\1/g" <<< "$BASH_VERSION") -lt "4" ];then
   exit 1;
 fi
 if [[ "$OSTYPE" == "darwin"* ]]; then
-  shopt -s expand_aliases
   for prog in "sed" "stat" "readlink"; do
     if [[ $(eval $prog --version 2>&1 | grep "GNU") == "" ]];then
       printf "ERROR: Please install the GNU version of '$prog' (g$prog)\ne.g. with 'brew install g$prog' and 'ln -s /usr/local/bin/g$prog /usr/local/bin/$prog' (make sure that /usr/local/bin comes before /usr/bin in \$PATH).\n"


### PR DESCRIPTION
I changed 3 small things (mainly to make the life easier for osx people)

1. update shebang to `/usr/bin/env bash` such that the bash executable is searched in PATH (again: osx people have bash version 3 as default and usually install a more up-to-date version of via brew, which is then picked up by env)
2. A check for BASH_VERSION >= 4 (which is needed for the globstar option)
3. only for OSX: check if GNU version of sed, stat, readlink are installed correctly (otherwise this script will just fail)

Feel free to change the error messages, those are just suggestions!

great project !

PS the `sed -E` command of 2 works for gnu-sed as well as the osx-sed