### PR TITLE
fix fresh-start crash with recent docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3'
+version: '3.5'
 
 services:
   nginx-proxy-automation-web:


### PR DESCRIPTION
`networks.<name>.name` is only valid for compose v3.5 and above. [Docs](https://docs.docker.com/compose/compose-file/compose-file-v3/#name-1)